### PR TITLE
chore: fix broken license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Contents in the `/src/content/articles` and `/src/content/info` folders are lice
 &copy; 2024 Sapphic Angels.
 
 [cc-license]: https://creativecommons.org/licenses/by-nc-sa/4.0/ 'Creative Commons CC-BY-NC-SA 4.0 International License'
-[license]: https://github.com/solelychloe/sapphic.moe/blob/main/LICENSE 'zlib License'
+[license]: LICENSE 'zlib License'


### PR DESCRIPTION
License link in README is broken, since it links directly to previous GitHub username `solelychloe` which isn't there anymore (as well as linking to `main` instead of `master`) and gives 404.
I updated it to link to relative `LICENSE` path instead of an absolute URL, which still opens it as `https://github.com/{username}/{repo}/blob/{branch}/LICENSE` in browser, but doesn't hardcode the username/repo, meaning it would also work fine when clicking on link locally, inside of a fork or if you decide to change username again.

P.S. you would probably want to also update year in README, since site says © 2016-2025 while README still says 2024